### PR TITLE
optionally include clang-tidy in CMake build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ script:
   - |
     cmake .. \
       --warn-uninitialized \
+      -DUSE_CLANG_TIDY:BOOL=ON \
       -DBasalt_CXX_OPTIMIZE:BOOL=$CXX_OPTIMIZE \
       -DCMAKE_CXX_STANDARD=$CPP \
   - make VERBOSE=1 -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ bob_begin_package()
 
 bob_option(Basalt_USE_pybind11 "Build Python bindings" OFF)
 bob_option(Basalt_BUILD_PYTHON_PACKAGE "Build Python package" OFF)
+bob_option(USE_CLANG_TIDY "Perform C++ static analysis while compiling" OFF)
 
 set(Basalt_SERIALIZATION_METHODS CEREAL SSTREAM)
 bob_input(Basalt_SERIALIZATION
@@ -72,6 +73,13 @@ set(pybind11_include_directory ${pybind11_project_directory}/include)
 set(spdlog_include_directory
     ${PROJECT_SOURCE_DIR}/src/third_party/spdlog/include)
 
+if(USE_CLANG_TIDY)
+  cmake_minimum_required(VERSION 3.8)
+  find_package(ClangTidy REQUIRED)
+  set(CLANG_TIDY_ARGS "-extra-arg=-Wno-unknown-warning-option"
+      CACHE STRING "clang-tidy command options")
+  set(CMAKE_CXX_CLANG_TIDY "${ClangTidy_EXECUTABLE}" ${CLANG_TIDY_ARGS})
+endif()
 add_subdirectory(src)
 if(NOT Basalt_BUILD_PYTHON_PACKAGE)
   add_subdirectory(tests/unit)

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -1,0 +1,72 @@
+# (based on https://github.com/BlueBrain/git-cmake-
+# format/blob/master/FindClangFormat.cmake)
+# ---------------
+# .rst: FindClangTidy
+# ---------------
+#
+# The module defines the following variables
+#
+# * ``ClangTidy_EXECUTABLE`` Path to clang-tidy executable
+# * ``ClangTidy_FOUND`` True if the clang-tidy executable was found
+# * ``ClangTidy_VERSION`` The version of clang-tidy found as a string
+# * ``ClangTidy_VERSION_MAJOR`` The clang-tidy major version
+# * ``ClangTidy_VERSION_MINOR`` The clang-tidy minor version
+# * ``ClangTidy_VERSION_PATCH`` The clang-tidy patch version
+
+find_program(ClangTidy_EXECUTABLE
+             NAMES clang-tidy
+                   clang-tidy-7
+                   clang-tidy-6.0
+                   clang-tidy-5.0
+                   clang-tidy-4.0
+                   clang-tidy-3.9
+                   clang-tidy-3.8
+                   clang-tidy-3.7
+                   clang-tidy-3.6
+                   clang-tidy-3.5
+             DOC "clang-tidy executable")
+
+# Extract version from command "clang-tidy -version"
+if(ClangTidy_EXECUTABLE)
+  execute_process(COMMAND ${ClangTidy_EXECUTABLE} -version
+                  OUTPUT_VARIABLE full_version_text
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # full_version_text sample:
+  # ~~~
+  # LLVM (http://llvm.org/):
+  #  LLVM version 7.0.1
+  #
+  #  Optimized build.
+  #  Default target: x86_64-pc-linux-gnu
+  #  Host CPU: skylake
+  # ~~~
+
+  if(full_version_text MATCHES "^LLVM .*")
+    string(REGEX
+           REPLACE ".*LLVM version ([0-9]\.[0-9]\.[0-9]).*"
+                   "\\1"
+                   ClangTidy_VERSION
+                   "${full_version_text}")
+    # ClangTidy_VERSION sample: "7.0.1"
+
+    # Extract version components
+    string(REPLACE "."
+                   ";"
+                   list_versions
+                   "${ClangTidy_VERSION}")
+    list(GET list_versions 0 ClangTidy_VERSION_MAJOR)
+    list(GET list_versions 1 ClangTidy_VERSION_MINOR)
+    list(GET list_versions 2 ClangTidy_VERSION_PATCH)
+    unset(list_versions)
+  endif()
+  unset(full_version_text)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ClangTidy
+                                  FOUND_VAR
+                                  ClangTidy_FOUND
+                                  REQUIRED_VARS
+                                  ClangTidy_EXECUTABLE
+                                  VERSION_VAR
+                                  ClangTidy_VERSION)


### PR DESCRIPTION
hopefully resolves #9

If USE_CLANG_TIDY=true then clang-tidy is included in the CMake build (for CMake version >= 3.6).

e.g.

cmake -DUSE_CLANG_TIDY=true ..

If clang-tidy returns an error then the build fails (for CMake version >= 3.8, for earlier versions CMake ignores the return value of clang-tidy)

Not enabled by default