### PR TITLE
Launch tests with valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons: &gcc7
       - g++-7
       - librocksdb-dev
       - python3-setuptools
+      - valgrind
     sources:
       - ubuntu-toolchain-r-test
 
@@ -40,7 +41,7 @@ matrix:
     - os: osx
   include:
       # Test gcc-7: C++11
-    - env: GCC_VERSION=7 CXX_OPTIMIZE=OFF CPP=11
+    - env: GCC_VERSION=7 CXX_OPTIMIZE=OFF CPP=11 VALGRIND="-T memcheck"
       os: linux
       dist: xenial
       addons: *gcc7
@@ -85,7 +86,7 @@ script:
       -DPYTHON_EXECUTABLE:FILEPATH=`which python3` \
       -DCMAKE_CXX_STANDARD=$CPP \
   - make VERBOSE=1 -j2
-  - ctest -j2 --output-on-failure
+  - ctest -j2 --output-on-failure ${VALGRIND}
   - cd ${TRAVIS_BUILD_DIR}
   - python3 setup.py build test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 project(Basalt VERSION 0.0.1 LANGUAGES CXX)
 
+include(cmake/DartConfig.cmake)
 include(cmake/bob.cmake)
 
 bob_begin_package()

--- a/cmake/DartConfig.cmake
+++ b/cmake/DartConfig.cmake
@@ -1,0 +1,31 @@
+# ---------------
+# .rst: DartConfig
+# ---------------
+#
+# CMake config file for DART
+#
+# This sets the following variables
+#
+# * ``DartConfig_SUPP_FILES`` List of all suppression files located on
+#   tests/ci/valgrind
+# * ``DartConfig_SUPP_LIST`` Concatenation of the suppression files with the
+#   format --supression=<supFile>
+# * ``MEMORYCHECK_COMMAND_OPTIONS`` Variable used to pass commands to valgrind
+
+file(GLOB DartConfig_SUPP_FILES
+          ${CMAKE_CURRENT_SOURCE_DIR}/tests/ci/valgrind/*.supp)
+foreach(supp_file IN LISTS DartConfig_SUPP_FILES)
+  set(DartConfig_SUPP_LIST
+      "${DartConfig_SUPP_LIST} --suppressions=${supp_file}")
+endforeach()
+
+find_program(MEMORYCHECK_COMMAND valgrind
+             DOC "Memory checking utility (valgrind by default)")
+
+set(
+  MEMORYCHECK_COMMAND_OPTIONS
+  "--tool=memcheck --track-origins=yes --leak-check=full --show-leak-kinds=all --verbose"
+  CACHE STRING "Commands passed to valgrind")
+
+set(MEMORYCHECK_COMMAND_OPTIONS
+    "${MEMORYCHECK_COMMAND_OPTIONS} ${DartConfig_SUPP_LIST}")

--- a/cmake/bob.cmake
+++ b/cmake/bob.cmake
@@ -57,8 +57,11 @@ macro(bob_begin_package)
   endif()
   option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" OFF)
   bob_cmake_arg(USE_XSDK_DEFAULTS BOOL OFF)
-  # try to force BUILD_TESTING to be OFF by default
-  set(BUILD_TESTING OFF CACHE BOOL "Build and run tests")
+  if(NOT MEMORYCHECK_COMMAND)
+    # try to force BUILD_TESTING to be OFF by default if memory check is not
+    # activated
+    set(BUILD_TESTING OFF CACHE BOOL "Build and run tests")
+  endif()
   include(CTest)
   enable_testing()
   option(BUILD_SHARED_LIBS "Build shared libraries" ON)


### PR DESCRIPTION
- Always runs test with valgrind only on gcc7 build 
- Default parameters passed to valgrind on cmake file DartConfig.cmake
- To change parameters: pass -DMEMORYCHECK_COMMAND_OPTIONS=<valgrind options> to cmake