### PR TITLE
Fix python setup.py sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,12 @@ script:
   - make VERBOSE=1 -j2
   - ctest -VV -j2 --output-on-failure ${VALGRIND}
   - cd ${TRAVIS_BUILD_DIR}
-  - python3 setup.py build test
+  - python3 setup.py sdist
+  - cd dist
+  - tarball=`echo *.tar.gz`
+  - tar zxf ${tarball}
+  - cd ${tarball%.tar.gz}
+  - python setup.py test
 
 notifications:
   email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include CMakeLists.txt
+recursive-include cmake *
+recursive-include include *
+recursive-include src *
+recursive-include tests *


### PR DESCRIPTION
Include in Python source distribution everything required to build the package.
Update Travis so that it builds the Python package from the source distribution