### PR TITLE
[#34] Install clang-tidy on TravisCI MacOS builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,12 @@ matrix:
         homebrew:
           packages:
           - rocksdb
+          - llvm
 
 before_script:
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
   - if [ -n "$CLANG_VERSION" ]; then export CXX="clang++-${CLANG_VERSION}" CC="clang-${CLANG_VERSION}"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX="clang++" CC="clang"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX="clang++" CC="clang"; ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"; fi
   - which $CXX
   - which $CC
   - $CXX --version


### PR DESCRIPTION
- Install with brew llvm --with-toolchain
- Use linking for finding clang-tidy executable
- Brew install llvm takes a lot of time and space