### PR TITLE
Fix basalt CLI doc command

### DIFF
--- a/basalt/__init__.py
+++ b/basalt/__init__.py
@@ -1,5 +1,6 @@
 import http.server
 import functools
+import os
 import os.path as osp
 
 from ._basalt import Status, Vertices, Edges, Graph, make_id
@@ -18,6 +19,11 @@ def serve_doc(bind="", port=8000):
     """
     doc_dir = osp.join(osp.dirname(__file__), "docs", "html")
     handler_class = functools.partial(
-        http.server.SimpleHTTPRequestHandler, directory=doc_dir
+        http.server.SimpleHTTPRequestHandler
     )
-    http.server.test(HandlerClass=handler_class, port=port, bind=bind)
+    cwd = os.getcwd()
+    try:
+        os.chdir(doc_dir)
+        http.server.test(HandlerClass=handler_class, port=port, bind=bind)
+    finally:
+        os.chdir(cwd)

--- a/basalt/cli.py
+++ b/basalt/cli.py
@@ -33,6 +33,7 @@ def main(argv=None):
     args = docopt(__doc__, version="basalt " + __version__, argv=argv)
     if args.get("doc"):
         port = args.get("<port>") or 8000
+        port = int(port)
         bind = args["--bind"]
         if bind == "all interfaces":
             bind = ""

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,15 @@ class BasaltTest(test):
         subprocess.check_call([sys.executable, __file__, "doctest"])
 
 
+install_requirements = [
+    "cached-property>=1.5.1",
+    "docopt>=0.6.2",
+    "h5py>=2.7.1",
+    "humanize>=0.5.1",
+    "numpy>=1.13",
+    "progress>=1.4",
+]
+
 setup(
     name="basalt",
     version="0.2.1",
@@ -164,15 +173,9 @@ setup(
     ),
     package_data={"basalt": ["doc/html/**/*"]},
     zip_safe=False,
-    install_requires=[
-        "cached-property>=1.5.1",
-        "docopt>=0.6.2",
-        "h5py>=2.7.1",
-        "humanize>=0.5.1",
-        "numpy>=1.13",
-        "progress>=1.4",
-    ],
-    setup_requires=["exhale", "m2r", "sphinx-rtd-theme", "sphinx<2"],
+    install_requires=install_requirements,
+    setup_requires=["exhale", "m2r", "sphinx-rtd-theme", "sphinx<2"]
+    + install_requirements,
     entry_points="""
         [console_scripts]
         basalt-cli = basalt.cli:main


### PR DESCRIPTION
* SimpleHTTPRequestHandler `directory` keyword is not supported in Python 3.6
* Fix argument parsing