### PR TITLE
schema: add empty ngv payloads to added vertices and edges if not specified

### DIFF
--- a/basalt/serialization.py
+++ b/basalt/serialization.py
@@ -13,10 +13,15 @@ class PickleSerialization:
     def deserialize(cls, obj):
         return pickle.loads(np.ndarray.tostring(obj))
 
+    @classmethod
+    def default_payload(cls):
+        return None
+
 
 class BasaltPayloadSerialization:
-    def __init__(self, payload_cls):
+    def __init__(self, payload_cls, default_payload):
         self.payload_cls = payload_cls
+        self._default_payload = default_payload
 
     def serialize(self, data):
         return data.serialize()
@@ -25,6 +30,11 @@ class BasaltPayloadSerialization:
         obj = self.payload_cls()
         obj.deserialize(data)
         return obj
+
+    def default_payload(self):
+        if self._default_payload:
+            return self.payload_cls()
+        return None
 
 
 class NoneSerialization:
@@ -36,12 +46,16 @@ class NoneSerialization:
     def deserialize(cls, data):
         return data
 
+    @classmethod
+    def default_payload(cls):
+        return None
 
-def serialization_method(name):
+
+def serialization_method(name, default_payload):
     if name == "pickle":
         return PickleSerialization
     elif getattr(name, "__module__", None) == "basalt._basalt.ngv":
-        return BasaltPayloadSerialization(name)
+        return BasaltPayloadSerialization(name, default_payload)
     elif name is None:
         return NoneSerialization
     else:

--- a/tests/py/ngv.py
+++ b/tests/py/ngv.py
@@ -132,7 +132,7 @@ class TestNGVGraph(unittest.TestCase):
         a1.add(n2)
 
         for neuron in a1.neurons:
-            self.assertEqual(neuron.data, None)
+            self.assertEqual(neuron.data, ngv.Neuron())
             self.assertEqual(neuron.id, 2)
 
         g.synapses.add(3)
@@ -140,7 +140,7 @@ class TestNGVGraph(unittest.TestCase):
         a1.add_synapse(3)
 
         for astrocyte in g.synapses[3].astrocytes:
-            self.assertEqual(astrocyte.data, None)
+            self.assertEqual(astrocyte.data, ngv.Astrocyte())
             self.assertEqual(astrocyte.id, 1)
 
         self.assertFalse(any(a1.discard_synapse(3).synapses))
@@ -148,11 +148,16 @@ class TestNGVGraph(unittest.TestCase):
     @ngv_graph
     def test_edges_payload_api(self, g):
         segment = g.segments.add(1)
+
+        # connect a segment to an astrocyte, with an implicit payload
+        astrocyte = g.astrocytes.add(1).add(segment)
+        self.assertEqual(astrocyte[segment], ngv.EdgeAstrocyteSegment())
+
+        # attach a payload on an edge between a segment and an astrocyte
         payload = ngv.EdgeAstrocyteSegment(
             astrocyte=ngv.Point(42.0, 43.0, 44.0),
             vasculature=ngv.Point(45.0, 46.0, 47.0),
         )
-        # attach a payload on an edge between a segment and an astrocyte
-        astrocyte = g.astrocytes.add(1).add(segment, payload)
+        astrocyte.add(segment, payload)
 
         self.assertEqual(astrocyte[segment], payload)


### PR DESCRIPTION
Unless told otherwise with the new `default_payload` bool option set to `False`
in `vertex` and `edge` directives, when a vertex or edge declared with
NGV payloads is added without an instance of payload, then a default one
is implicitly added.

Fixes #65 