### PR TITLE
New --no-doc-test option for 'python setup.py test' command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,13 +115,21 @@ class PkgTest(test):
     for the "test" command.
     """
 
-    new_commands = [('test_ext', lambda self: True), ('test_doc', lambda self: True)]
+    user_options = test.user_options + [
+        ('no-doc-test', None, "Do not test documentation snippets"),
+    ]
+    new_commands = [('test_ext', lambda self: true), ('test_doc', lambda self: not self.no_doc_test)]
     sub_commands = test.sub_commands + new_commands
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.no_doc_test = False
 
     def run(self):
         super().run()
         self.run_command('test_ext')
-        self.run_command('test_doc')
+        if not self.no_doc_test:
+            self.run_command('test_doc')
 
 
 install_requirements = ["cached-property>=1.5.1", "numpy>=1.11"]


### PR DESCRIPTION
Evaluation of the snippets crash in some environments. It seems
the NumPy package is initialized twice, for instance:

```
WARNING: autodoc: failed to import module 'serialization' from module 'basalt'; the following exception was raised:
Traceback (most recent call last):
  File "/gpfs/bbp.cscs.ch/home/tcarel/software/install/linux-rhel7-x86_64/gcc-8.3.0/py-sphinx-2.4.2-mnvczk/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 32, in import_module
    return importlib.import_module(modname)
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/external-libraries/2020-02-01/linux-rhel7-x86_64/gcc-8.3.0/python-3.7.4-tfxecymrkn/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/gpfs/bbp.cscs.ch/home/tcarel/src/github.com/tristan0x/basalt/basalt/serialization.py", line 10, in <module>
    import numpy as np
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/libraries/2020-02-01/linux-rhel7-x86_64/gcc-8.3.0/py-numpy-1.17.3-edmewrnybo/lib/python3.7/site-packages/numpy/__init__.py", line 142, in <module>
    from . import core
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/libraries/2020-02-01/linux-rhel7-x86_64/gcc-8.3.0/py-numpy-1.17.3-edmewrnybo/lib/python3.7/site-packages/numpy/core/__init__.py", line 17, in <module>
    from . import multiarray
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/libraries/2020-02-01/linux-rhel7-x86_64/gcc-8.3.0/py-numpy-1.17.3-edmewrnybo/lib/python3.7/site-packages/numpy/core/multiarray.py", line 14, in <module>
    from . import overrides
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/libraries/2020-02-01/linux-rhel7-x86_64/gcc-8.3.0/py-numpy-1.17.3-edmewrnybo/lib/python3.7/site-packages/numpy/core/overrides.py", line 47, in <module>
    """)
RuntimeError: implement_array_function method already has a docstring
```